### PR TITLE
docs: READMEを現行構成に合わせて更新

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Industry-Specific MC Training Platform
 
-LINE認証をベースとした業界特化型AIマーケティング支援プラットフォーム。Fine-tuned AIモデル、3つの専門プロンプト、Canvas描画機能、WordPress連携、サブスクリプション決済を統合した包括的なSaaSアプリケーションです。
+LINE認証をベースとした業界特化型AIマーケティング支援プラットフォーム。Fine-tuned AIモデル、広告/LP/ブログ向けテンプレート群、Canvas描画機能、WordPress連携、サブスクリプション決済を統合した包括的なSaaSアプリケーションです。
 
 ## 🚀 主要機能
 
@@ -14,10 +14,10 @@ LINE認証をベースとした業界特化型AIマーケティング支援プ�
 ### 🤖 AIマーケティング支援機能
 
 - **Fine-tuned AIモデル**：`ft:gpt-4.1-nano-2025-04-14` によるキーワード分類
-- **3つの専門プロンプト**：広告文作成・仕上げ、16パートLP作成（5W2H準拠）
-- **プロンプト管理**：管理者専用リアルタイム編集・バージョン履歴・18項目動的変数置換
-- **外部API統合**：Google検索（使用量制限付き）
-- **チャット機能**：履歴永続化・セッション管理・AIモデル選択
+- **テンプレート体系**：広告文（作成/仕上げ）、16パートLP草案/改善、7ステップのブログ作成フローなど複数の業務特化プロンプトを提供
+- **プロンプト管理**：管理者専用リアルタイム編集・バージョン履歴・変数付きテンプレート管理
+- **外部API統合**：Google検索回数トラッキング（※検索API本体は廃止済み）
+- **チャット機能**：Anthropic Claude Sonnet-4 とのストリーミング会話、セッション管理、AIモデル選択
 
 ### 🎨 ランディングページ作成・WordPress連携
 
@@ -44,59 +44,57 @@ graph TB
     subgraph "Frontend Layer"
         A[Next.js 15 App Router]
         B[React 19 Components]
-        C[Custom Hooks]
-        D[Canvas API]
+        C[Canvas / TipTap Editor]
+        D[LIFF Hooks]
     end
 
     subgraph "Authentication"
         E[LINE LIFF 2.25]
-        F[JWT Token Auto-Refresh]
+        F[Token Auto-Refresh Middleware]
     end
 
     subgraph "Business Logic"
         G[Server Actions]
-        H[Domain Services]
-        I[RAG System]
-        J[Middleware]
+        H[Prompt Template Service]
+        I[WordPress Integration]
+        J[Chat Streaming Controller]
     end
 
     subgraph "Data Layer"
         K[Supabase PostgreSQL + RLS]
-        M[Vector Embeddings]
+        L[Prompt Templates & Versions]
+        M[WordPress Settings]
     end
 
     subgraph "AI Models"
-        N[Fine-tuned OpenAI GPT-4]
-        O[Claude Sonnet-4]
-        P[RAG Retrieval]
-        Q[Embedding Models]
+        N[Fine-tuned OpenAI GPT-4.1 Nano]
+        O[Anthropic Claude Sonnet-4]
     end
 
     subgraph "External APIs"
         R[Stripe 17.7]
-        S[WordPress APIs]
-        T[Google Search API]
-
+        S[WordPress REST / OAuth]
+        T[Google Search Quota Tracker]
         V[LINE Platform API]
     end
 
     A --> E
     A --> G
     B --> C
-    B --> D
+    C --> J
     E --> F
+    F --> G
     G --> H
-    H --> I
+    G --> I
     G --> K
+    H --> L
     I --> M
-    I --> P
+    J --> O
     H --> N
-    H --> O
-    H --> Q
-    H --> R
-    H --> S
-    H --> T
-    H --> V
+    G --> R
+    I --> S
+    G --> T
+    F --> V
 ```
 
 ## 🔄 認証フロー
@@ -126,10 +124,10 @@ sequenceDiagram
 
 ## 🛠️ 技術スタック
 
-**フロントエンド**: Next.js 15.3.1 + React 19 + TypeScript 5 + Tailwind CSS 4 + Radix UI + TipTap 3.0.7
-**バックエンド**: Supabase 2.49.1（PostgreSQL + RLS）+ プロンプト管理システム
-**AI**: OpenAI GPT-4（Fine-tuned）+ Anthropic Claude Sonnet-4
-**外部API**: Google Search + LINE LIFF 2.25.1 + Stripe 17.7 + WordPress API
+**フロントエンド**: Next.js 15.4.7 + React 19 + TypeScript 5 + Tailwind CSS 4 + Radix UI + TipTap 3.0.7
+**バックエンド**: Supabase 2.49.1（PostgreSQL + RLS）+ プロンプトテンプレート/WordPress連携サービス
+**AI**: OpenAI GPT-4.1 Nano（Fine-tuned）+ Anthropic Claude Sonnet-4
+**外部API**: Google Custom Search（回数カウントのみ）+ LINE LIFF 2.25.1 + Stripe 17.7 + WordPress REST API
 **開発**: Vercel + Husky + ESLint 9 + Prettier + tsc-watch + ngrok
 
 ## 📊 データベーススキーマ
@@ -223,25 +221,38 @@ erDiagram
     prompt_templates ||--o{ prompt_versions : has
 ```
 
-## 📋 環境変数設定（全27項目）
+## 📋 環境変数設定（全19項目）
 
-### サーバーサイド環境変数
+`src/env.ts` で型定義されているサーバー/クライアント環境変数は以下の19項目です。`.env.example` はリポジトリに含まれないため、`.env.local` を手動で作成して設定してください。
 
-- **データベース**: DBPASS, SUPABASE_SERVICE_ROLE
-- **決済**: STRIPE_ENABLED, STRIPE_SECRET_KEY, STRIPE_PRICE_ID
-- **AI**: OPENAI_API_KEY, ANTHROPIC_API_KEY
-- **検索**: GOOGLE_CUSTOM_SEARCH_KEY, GOOGLE_CSE_ID
-- **LINE**: LINE_CHANNEL_ID, LINE_CHANNEL_SECRET
+| 種別 | 変数名 | 必須 | 用途 |
+| ---- | ------ | ---- | ---- |
+| Server | `DBPASS` | ✅ | Supabase から接続されるデータベースパスワード |
+| Server | `SUPABASE_SERVICE_ROLE` | ✅ | サーバーサイド処理で使用する Service Role キー |
+| Server | `STRIPE_ENABLED` | 任意 | Stripe を有効化するフラグ（`true/false`） |
+| Server | `STRIPE_SECRET_KEY` | ✅（決済有効時） | Stripe シークレットキー |
+| Server | `STRIPE_PRICE_ID` | ✅（決済有効時） | Stripe サブスクリプションの Price ID |
+| Server | `OPENAI_API_KEY` | ✅ | Fine-tuned モデル利用時の OpenAI キー |
+| Server | `ANTHROPIC_API_KEY` | ✅ | Claude ストリーミング用 API キー |
+| Server | `GOOGLE_CUSTOM_SEARCH_KEY` | ✅ | Google Custom Search API キー（回数カウントで利用） |
+| Server | `GOOGLE_CSE_ID` | ✅ | Google Custom Search Engine ID |
+| Server | `LINE_CHANNEL_ID` | ✅ | LINE Login 用チャネル ID |
+| Server | `LINE_CHANNEL_SECRET` | ✅ | LINE Login 用チャネルシークレット |
+| Server | `BASE_WEBHOOK_URL` | ✅ | ログ転送先（Lark Base など）の Webhook URL |
+| Server | `RELAY_BEARER_TOKEN` | ✅ | `/api/log-relay` の Bearer 認証トークン |
+| Client | `NEXT_PUBLIC_LIFF_ID` | ✅ | LIFF アプリ ID |
+| Client | `NEXT_PUBLIC_LIFF_CHANNEL_ID` | ✅ | LIFF Channel ID |
+| Client | `NEXT_PUBLIC_SUPABASE_URL` | ✅ | Supabase プロジェクト URL |
+| Client | `NEXT_PUBLIC_SUPABASE_ANON_KEY` | ✅ | Supabase anon キー |
+| Client | `NEXT_PUBLIC_SITE_URL` | ✅ | サイト公開 URL |
+| Client | `NEXT_PUBLIC_STRIPE_ENABLED` | 任意 | クライアント側の Stripe 有効化フラグ |
 
-- **Webhook**: BASE_WEBHOOK_URL, RELAY_BEARER_TOKEN
+### 追加で利用できる任意設定
 
-### クライアントサイド環境変数
-
-- **LINE**: NEXT_PUBLIC_LIFF_ID, NEXT_PUBLIC_LIFF_CHANNEL_ID
-- **データベース**: NEXT_PUBLIC_SUPABASE_URL, NEXT_PUBLIC_SUPABASE_ANON_KEY
-- **サイト**: NEXT_PUBLIC_SITE_URL
-
-- **決済**: NEXT_PUBLIC_STRIPE_ENABLED
+- `WORDPRESS_COM_CLIENT_ID`, `WORDPRESS_COM_CLIENT_SECRET`, `WORDPRESS_COM_REDIRECT_URI`: WordPress.com OAuth を利用する場合に必要。
+- `OAUTH_STATE_COOKIE_NAME`, `OAUTH_TOKEN_COOKIE_NAME`: WordPress OAuth 状態管理用クッキー名をカスタマイズする際に利用。
+- `COOKIE_SECRET`: WordPress OAuth コールバックで安全にトークンを保存するために必須。
+- `RELAY_PROJECT_ID`: `/api/log-relay` の自己ループ防止用に設定可能。
 
 ## 🚀 環境構築手順
 
@@ -258,7 +269,7 @@ erDiagram
 ```bash
 git clone <repository-url> && cd industry-specific-mc-training
 npm install
-cp .env.example .env.local  # 環境変数設定（27項目）
+# .env.local を作成し上記19項目を設定
 npx supabase db push       # DBマイグレーション
 npm run dev               # 開発サーバー起動
 npm run ngrok             # LINE LIFF用HTTPSトンネル（別ターミナル）
@@ -277,10 +288,14 @@ npm run ngrok             # LINE LIFF用HTTPSトンネル（別ターミナル�
 │   │   ├── prompts/         # プロンプト管理システム
 │   │   └── layout.tsx       # 管理者レイアウト
 │   ├── api/                 # API Routes
-│   │   ├── line/           # LINE認証API
-│   │   ├── wordpress/      # WordPress連携API
-│   │   ├── user/           # ユーザー管理API
-│   │   └── ad-form/        # LP作成API
+│   │   ├── admin/         # 管理者専用API（プロンプト・統計）
+│   │   ├── auth/          # ロール確認・キャッシュクリア
+│   │   ├── chat/          # AnthropicストリーミングAPI
+│   │   ├── line/          # LINE認証API
+│   │   ├── log-relay/     # Vercel Log Drain 中継
+│   │   ├── refresh/       # LINEトークンリフレッシュ
+│   │   ├── user/          # ユーザー情報API
+│   │   └── wordpress/     # WordPress連携API
 │   ├── chat/               # チャット機能
 │   │   ├── components/     # チャット専用コンポーネント
 │   │   │   ├── CanvasPanel.tsx    # Canvas描画パネル
@@ -288,6 +303,7 @@ npm run ngrok             # LINE LIFF用HTTPSトンネル（別ターミナル�
 │   │   │   ├── MessageArea.tsx    # メッセージ表示
 │   │   │   └── SessionSidebar.tsx # セッション管理
 │   │   └── page.tsx        # チャットメインページ
+│   ├── analytics/          # アナリティクス表示
 │   ├── business-info/      # 事業情報入力
 │   ├── setup/              # 初期設定ウィザード
 │   └── subscription/       # サブスクリプション管理
@@ -310,22 +326,47 @@ npm run ngrok             # LINE LIFF用HTTPSトンネル（別ターミナル�
 
 ## 🔧 主要なAPIエンドポイント
 
-| エンドポイント                     | 機能                             | 新機能    |
-| ---------------------------------- | -------------------------------- | --------- |
-| `/api/line/callback`               | LINE認証コールバック             | -         |
-| `/api/refresh`                     | トークンリフレッシュ             | -         |
-| `/api/user/current`                | 現在のユーザー情報・権限         | -         |
-| `/api/user/search-count`           | Google検索使用量確認             | -         |
-| `/api/wordpress/test-connection`   | WordPress接続テスト              | -         |
-| `/api/wordpress/oauth/start`       | WordPress.com OAuth開始          | -         |
-| `/api/wordpress/oauth/callback`    | WordPress.com OAuth コールバック | -         |
-| `/api/ad-form/create-landing-page` | ランディングページ作成           | -         |
-| `/api/rag/*`                       | RAG検索・拡張生成                | ✨ 新機能 |
+### 管理者向け
+
+| エンドポイント | メソッド | 主な役割 | 認証 |
+| -------------- | -------- | -------- | ---- |
+| `/api/admin/prompts` | GET | 全プロンプトテンプレートの一覧取得 | LINEアクセス/リフレッシュトークン + 管理者ロール |
+| `/api/admin/prompts/[id]` | GET/POST | 個別テンプレートの閲覧・更新 | LINEアクセス/リフレッシュトークン + 管理者ロール |
+| `/api/admin/wordpress/stats` | GET | WordPress連携状況の集計 | LINEアクセス/リフレッシュトークン + 管理者ロール |
+
+### 認証・ユーザー
+
+| エンドポイント | メソッド | 主な役割 | 認証 |
+| -------------- | -------- | -------- | ---- |
+| `/api/line/callback` | GET | LINE OAuth コールバック・トークン保存 | 公開（state チェックあり） |
+| `/api/refresh` | POST | LINE リフレッシュトークンから再発行 | リフレッシュトークン Cookie |
+| `/api/auth/check-role` | GET | 現在のユーザーロール確認 | LINE アクセストークン Cookie |
+| `/api/auth/clear-cache` | POST | クライアントへキャッシュクリア通知 | 任意（特権操作不要） |
+| `/api/user/current` | GET | ログインユーザー情報・ロール取得 | LINE アクセス/リフレッシュトークン Cookie |
+| `/api/user/search-count` | GET | Google検索機能の提供終了通知（410返却） | 任意 |
+
+### WordPress連携
+
+| エンドポイント | メソッド | 主な役割 | 認証 |
+| -------------- | -------- | -------- | ---- |
+| `/api/wordpress/settings` | POST | WordPress.com/セルフホスト設定の保存 | LINE アクセス/リフレッシュトークン Cookie |
+| `/api/wordpress/status` | GET | WordPress接続状態の確認 | LINE アクセス/リフレッシュトークン Cookie |
+| `/api/wordpress/test-connection` | GET/POST | WordPress接続テストの実行 | LINE アクセス/リフレッシュトークン Cookie |
+| `/api/wordpress/posts` | GET | WordPress投稿一覧の取得 | LINE アクセス/リフレッシュトークン Cookie + WP 認証 |
+| `/api/wordpress/oauth/start` | GET | WordPress.com OAuth リダイレクト開始 | 公開（WordPress OAuth 環境変数必須） |
+| `/api/wordpress/oauth/callback` | GET | WordPress.com OAuth コールバック処理 | LINE アクセス/リフレッシュトークン Cookie |
+
+### その他
+
+| エンドポイント | メソッド | 主な役割 | 認証 |
+| -------------- | -------- | -------- | ---- |
+| `/api/chat/anthropic/stream` | POST | Claude Sonnet-4 とのSSEストリーミング | Authorization Bearer（LIFFアクセストークン） |
+| `/api/log-relay` | POST/GET/HEAD/OPTIONS | Vercel Log Drain の受け口・Bearer検証・Webhook転送 | `Authorization: Bearer ${RELAY_BEARER_TOKEN}` |
 
 ## 🛡️ セキュリティ機能
 
 - **Row Level Security (RLS)** - データベースレベルでのマルチテナント分離
-- **管理者権限制御** - `/admin`, `/setup`, `/debug`, `/studio` への階層化アクセス
+- **認可ミドルウェア** - `/login`・`/unauthorized`・`/` 以外のページは LIFF アクセストークン必須、`/admin/*` は管理者ロール限定、`/analytics` `/business-info` `/setup` `/subscription` などは認証済みユーザー専用
 - **JWT Token管理** - 自動リフレッシュ + 5分TTLメモリキャッシュ
 - **CSRF保護** - 状態トークンによる保護
 - **環境変数管理** - @t3-oss/env-nextjs による型安全な機密情報管理
@@ -350,8 +391,8 @@ npm run ngrok             # LINE LIFF用HTTPSトンネル（別ターミナル�
 
 ## 📈 2025年8月最新アップデート
 
-**新機能**: Canvas描画（TipTap 3.0.7）、プロンプト管理システム、WordPress連携強化、管理者ダッシュボード
-**アーキテクチャ**: Clean Architecture準拠、型安全性向上（27項目環境変数管理）
+**新機能**: Canvas描画（TipTap 3.0.7）、多段ブログ作成フロー、プロンプト管理システム、WordPress連携強化、管理者ダッシュボード
+**アーキテクチャ**: Clean Architecture準拠、型安全性向上（19項目の型付き環境変数管理）
 **開発効率**: ESLint 9 + Prettier統合、自動品質管理
 
 ## 🤝 コントリビューション


### PR DESCRIPTION
## Summary
- READMEの主要機能・技術スタックを現行依存関係とプロンプト構成に合わせて更新
- APIエンドポイント表とセキュリティ説明を最新のルート構成・ミドルウェア挙動に沿って整理
- 環境変数とセットアップ手順を `src/env.ts` ベースの19項目に合わせて刷新

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68da44ddb82c8322936239316e81c288